### PR TITLE
Bower main field should not point to minified file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
   "version": "0.1.0",
   "description": "A small initial caps jQuery plugin",
   "main": [
-    "dist/js/jquery-initialcaps.min.js"
+    "src/js/jquery-initialcaps.js"
   ],
   "scripts": [
     "dist/js/jquery-initialcaps.min.js"


### PR DESCRIPTION
According to Bower guidelines:

> The "main" field cannot contain minified files

(In order to let users minify it with their preferred tool.)
